### PR TITLE
:tractor: Fixes name

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ bootstrap:  ## installs/updates all dependencies
     set -euo pipefail
     if [ ! -f "{{ENV_FILE}}" ]; then
         echo "{{ENV_FILE}} created"
-        cp .env-dist {{ENV_FILE}}
+        cp env.template {{ENV_FILE}}
     fi
 
     # docker-compose --file $(COMPOSE_FILE) build --force-rm


### PR DESCRIPTION
I would consider renaming `env.template` to lead with a `.` so that other env tooling will work with it. `.env.example` is probably the more common naming pattern but that takes a docs update too.