### PR TITLE
Order older versions by release date, descending 

### DIFF
--- a/versions/tests/fixtures.py
+++ b/versions/tests/fixtures.py
@@ -61,7 +61,7 @@ def old_version(db):
     last_year = datetime.date.today() - datetime.timedelta(days=365)
     v = baker.make(
         "versions.Version",
-        name="Version 1.79.0",
+        name="Version 1.70.0",
         description="Some awesome description of the library",
         release_date=last_year,
     )

--- a/versions/tests/test_views.py
+++ b/versions/tests/test_views.py
@@ -3,7 +3,7 @@ import datetime
 from model_bakery import baker
 
 
-def test_version_list(version, old_version, tp):
+def test_version_list(version, tp):
     """
     GET /versions/
     """

--- a/versions/tests/test_views.py
+++ b/versions/tests/test_views.py
@@ -1,4 +1,9 @@
-def test_version_list(version, tp):
+import datetime
+
+from model_bakery import baker
+
+
+def test_version_list(version, old_version, tp):
     """
     GET /versions/
     """
@@ -10,14 +15,22 @@ def test_version_list_context(version, old_version, inactive_version, tp):
     """
     GET /versions/
     """
+    older_version = baker.make(
+        "versions.Version",
+        name="Version 1.67.0",
+        description="Sample",
+        release_date=datetime.date.today() - datetime.timedelta(days=700),
+    )
     res = tp.get("version-list")
     tp.response_200(res)
     assert "current_version" in res.context
     assert "version_list" in res.context
+    assert len(res.context["version_list"]) == 2
     assert res.context["current_version"] == version
     assert old_version in res.context["version_list"]
+    assert older_version in res.context["version_list"]
+    assert old_version == res.context["version_list"][0]
     assert inactive_version not in res.context["version_list"]
-    assert len(res.context["version_list"]) == 1
 
 
 def test_version_detail(version, tp):

--- a/versions/views.py
+++ b/versions/views.py
@@ -7,7 +7,7 @@ class VersionList(ListView):
     """Web display of list of Versions"""
 
     model = Version
-    queryset = Version.objects.active()
+    queryset = Version.objects.active().order_by("-release_date")
     template_name = "versions/list.html"
 
     def get_context_data(self):


### PR DESCRIPTION
Broke this out of https://github.com/revsys/boost.org/pull/108 to make that PR more manageable. 

- Reorders the versions on the version list page in descending order by `release_date`  