### PR TITLE
Libraries by version views

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -139,7 +139,7 @@ urlpatterns = [
     path(
         "versions/<slug:version_slug>/libraries/<slug:slug>/",
         LibraryDetailByVersion.as_view(),
-        name="libraries-by-version-detail",
+        name="library-detail-by-version",
     ),
     path(
         "versions/<slug:slug>/libraries/",

--- a/config/urls.py
+++ b/config/urls.py
@@ -137,7 +137,8 @@ urlpatterns = [
     ),
     path("contact/", ContactView.as_view(), name="contact"),
     # Boost versions views
-    path("versions/<slug:version_slug>/libraries-by-category/<slug:category>/",
+    path(
+        "versions/<slug:version_slug>/libraries-by-category/<slug:category>/",
         LibraryListByVersionByCategory.as_view(),
         name="libraries-by-version-by-category",
     ),

--- a/config/urls.py
+++ b/config/urls.py
@@ -133,8 +133,7 @@ urlpatterns = [
         TemplateView.as_view(template_name="support/getting_started.html"),
         name="getting-started",
     ),
-    path("contact/", ContactView.as_view(), name="contact"),\
-    # Boost versions views
+    path("contact/", ContactView.as_view(), name="contact"),  # Boost versions views
     path(
         "versions/<slug:slug>/libraries/",
         LibraryListByVersion.as_view(),

--- a/config/urls.py
+++ b/config/urls.py
@@ -21,6 +21,7 @@ from libraries.views import (
     LibraryDetail,
     LibraryListByVersion,
     LibraryDetailByVersion,
+    LibraryListByVersionByCategory,
 )
 from libraries.api import LibrarySearchView
 from support.views import SupportView, ContactView
@@ -136,6 +137,10 @@ urlpatterns = [
     ),
     path("contact/", ContactView.as_view(), name="contact"),
     # Boost versions views
+    path("versions/<slug:version_slug>/libraries-by-category/<slug:category>/",
+        LibraryListByVersionByCategory.as_view(),
+        name="libraries-by-version-by-category",
+    ),
     path(
         "versions/<slug:slug>/libraries/",
         LibraryListByVersion.as_view(),

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,6 +20,7 @@ from libraries.views import (
     LibraryByCategory,
     LibraryDetail,
     LibraryListByVersion,
+    LibraryDetailByVersion,
 )
 from libraries.api import LibrarySearchView
 from support.views import SupportView, ContactView
@@ -44,6 +45,11 @@ urlpatterns = [
     path("403", ForbiddenView.as_view(), name="forbidden"),
     path("404", NotFoundView.as_view(), name="not_found"),
     path("500", InternalServerErrorView.as_view(), name="internal_server_error"),
+    path(
+        "about/",
+        TemplateView.as_view(template_name="boost/about.html"),
+        name="boost-about",
+    ),
     path("health/", include("health_check.urls")),
     path("forum/", include(machina_urls)),
     path(
@@ -61,11 +67,6 @@ urlpatterns = [
         "libraries/<slug:slug>/",
         LibraryDetail.as_view(),
         name="library-detail",
-    ),
-    path(
-        "about/",
-        TemplateView.as_view(template_name="boost/about.html"),
-        name="boost-about",
     ),
     path(
         "people/detail/",
@@ -133,7 +134,13 @@ urlpatterns = [
         TemplateView.as_view(template_name="support/getting_started.html"),
         name="getting-started",
     ),
-    path("contact/", ContactView.as_view(), name="contact"),  # Boost versions views
+    path("contact/", ContactView.as_view(), name="contact"),
+    # Boost versions views
+    path(
+        "versions/<slug:version_slug>/libraries/<slug:slug>/",
+        LibraryDetailByVersion.as_view(),
+        name="libraries-by-version-detail",
+    ),
     path(
         "versions/<slug:slug>/libraries/",
         LibraryListByVersion.as_view(),

--- a/config/urls.py
+++ b/config/urls.py
@@ -19,6 +19,7 @@ from libraries.views import (
     LibraryList,
     LibraryByCategory,
     LibraryDetail,
+    LibraryListByVersion,
 )
 from libraries.api import LibrarySearchView
 from support.views import SupportView, ContactView
@@ -132,7 +133,13 @@ urlpatterns = [
         TemplateView.as_view(template_name="support/getting_started.html"),
         name="getting-started",
     ),
-    path("contact/", ContactView.as_view(), name="contact"),
+    path("contact/", ContactView.as_view(), name="contact"),\
+    # Boost versions views
+    path(
+        "versions/<slug:slug>/libraries/",
+        LibraryListByVersion.as_view(),
+        name="libraries-by-version",
+    ),
     path("versions/<slug:slug>/", VersionDetail.as_view(), name="version-detail"),
     path("versions/", VersionList.as_view(), name="version-list"),
     # Markdown content

--- a/config/urls.py
+++ b/config/urls.py
@@ -137,14 +137,14 @@ urlpatterns = [
     path("contact/", ContactView.as_view(), name="contact"),
     # Boost versions views
     path(
-        "versions/<slug:version_slug>/libraries/<slug:slug>/",
-        LibraryDetailByVersion.as_view(),
-        name="library-detail-by-version",
-    ),
-    path(
         "versions/<slug:slug>/libraries/",
         LibraryListByVersion.as_view(),
         name="libraries-by-version",
+    ),
+    path(
+        "versions/<slug:version_slug>/<slug:slug>/",
+        LibraryDetailByVersion.as_view(),
+        name="library-detail-by-version",
     ),
     path("versions/<slug:slug>/", VersionDetail.as_view(), name="version-detail"),
     path("versions/", VersionList.as_view(), name="version-list"),

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -26,6 +26,20 @@ def test_libraries_by_category(tp, library, category):
     assert res.context["category"] == category
 
 
+def test_libraries_by_version(tp, library_version):
+    """GET /versions/{version_identifier}/libraries/"""
+    # Create a new library_version
+    excluded_library = baker.make("libraries.Library", name="Sample")
+    res = tp.get("libraries-by-version", library_version.version.slug)
+    tp.response_200(res)
+    assert "library_list" in res.context
+
+    # Confirm that correct libraries are present
+    assert len(res.context["library_list"]) == 1
+    assert library_version.library in res.context["library_list"]
+    assert excluded_library not in res.context["library_list"]
+
+
 def test_library_detail(library, tp):
     """GET /libraries/{repo}/"""
     url = tp.reverse("library-detail", library.slug)

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -27,10 +27,10 @@ def test_libraries_by_category(tp, library, category):
 
 
 def test_libraries_by_version_detail(tp, library_version):
-    """GET /versions/{version_identifier}/libraries/{slug}/"""
+    """GET /versions/{version_slug}/libraries/{slug}/"""
     res = tp.get(
-        "libraries-by-version-detail",
-        library_version.version.pk,
+        "library-detail-by-version",
+        library_version.version.slug,
         library_version.library.slug,
     )
     tp.response_200(res)
@@ -40,9 +40,19 @@ def test_libraries_by_version_detail(tp, library_version):
 def test_libraries_by_version_detail_no_library_found(tp, library_version):
     """GET /versions/{version_identifier}/libraries/{slug}/"""
     res = tp.get(
-        "libraries-by-version-detail",
-        library_version.version.pk,
+        "library-detail-by-version",
+        library_version.version.slug,
         "coffee",
+    )
+    tp.response_404(res)
+
+
+def test_libraries_by_version_detail_no_version_found(tp, library_version):
+    """GET /versions/{version_identifier}/libraries/{slug}/"""
+    res = tp.get(
+        "library-detail-by-version",
+        "coffee",
+        library_version.library.slug,
     )
     tp.response_404(res)
 

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -13,11 +13,24 @@ def test_library_list_select_category(library, category, tp):
     tp.response_302(res)
 
 
-def test_libraries_by_category(tp, library, category):
-    """GET /libraries-by-category/{slug}/"""
-    baker.make("libraries.Library", name="Sample")
+def test_library_list_by_category(library_version, category, tp):
+    """GET /libraries-by-category/{category_slug}/"""
+    library = library_version.library
+    version = library_version.version
     library.categories.add(category)
     res = tp.get("libraries-by-category", category.slug)
+    tp.response_302(res)
+    assert res.url == f"/versions/{version.pk}/libraries-by-category/{category.slug}/"
+
+
+def test_libraries_by_version_by_category(tp, library_version, category):
+    """GET /versions/{version_slug}/libraries-by-category/{slug}/"""
+    library = library_version.library
+    version = library_version.version
+
+    baker.make("libraries.Library", name="Sample")
+    library.categories.add(category)
+    res = tp.get("libraries-by-version-by-category", version.pk, category.slug)
     tp.response_200(res)
     assert "library_list" in res.context
     assert len(res.context["library_list"]) == 1
@@ -57,8 +70,8 @@ def test_libraries_by_version_detail_no_version_found(tp, library_version):
     tp.response_404(res)
 
 
-def test_libraries_by_version(tp, library_version):
-    """GET /versions/{version_identifier}/libraries/"""
+def test_libraries_by_version_list(tp, library_version):
+    """GET /versions/{version_slug}/libraries/"""
     # Create a new library_version
     excluded_library = baker.make("libraries.Library", name="Sample")
     res = tp.get("libraries-by-version", library_version.version.slug)

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -26,6 +26,27 @@ def test_libraries_by_category(tp, library, category):
     assert res.context["category"] == category
 
 
+def test_libraries_by_version_detail(tp, library_version):
+    """GET /versions/{version_identifier}/libraries/{slug}/"""
+    res = tp.get(
+        "libraries-by-version-detail",
+        library_version.version.pk,
+        library_version.library.slug,
+    )
+    tp.response_200(res)
+    assert "version" in res.context
+
+
+def test_libraries_by_version_detail_no_library_found(tp, library_version):
+    """GET /versions/{version_identifier}/libraries/{slug}/"""
+    res = tp.get(
+        "libraries-by-version-detail",
+        library_version.version.pk,
+        "coffee",
+    )
+    tp.response_404(res)
+
+
 def test_libraries_by_version(tp, library_version):
     """GET /versions/{version_identifier}/libraries/"""
     # Create a new library_version

--- a/libraries/tests/test_views.py
+++ b/libraries/tests/test_views.py
@@ -7,83 +7,6 @@ def test_library_list(library, tp):
     tp.response_200(res)
 
 
-def test_library_list_select_category(library, category, tp):
-    """POST /libraries/ to submit a category redirects to the libraries-by-category page"""
-    res = tp.post("libraries", data={"categories": category.pk})
-    tp.response_302(res)
-
-
-def test_library_list_by_category(library_version, category, tp):
-    """GET /libraries-by-category/{category_slug}/"""
-    library = library_version.library
-    version = library_version.version
-    library.categories.add(category)
-    res = tp.get("libraries-by-category", category.slug)
-    tp.response_302(res)
-    assert res.url == f"/versions/{version.pk}/libraries-by-category/{category.slug}/"
-
-
-def test_libraries_by_version_by_category(tp, library_version, category):
-    """GET /versions/{version_slug}/libraries-by-category/{slug}/"""
-    library = library_version.library
-    version = library_version.version
-
-    baker.make("libraries.Library", name="Sample")
-    library.categories.add(category)
-    res = tp.get("libraries-by-version-by-category", version.pk, category.slug)
-    tp.response_200(res)
-    assert "library_list" in res.context
-    assert len(res.context["library_list"]) == 1
-    assert library in res.context["library_list"]
-    assert "category" in res.context
-    assert res.context["category"] == category
-
-
-def test_libraries_by_version_detail(tp, library_version):
-    """GET /versions/{version_slug}/libraries/{slug}/"""
-    res = tp.get(
-        "library-detail-by-version",
-        library_version.version.slug,
-        library_version.library.slug,
-    )
-    tp.response_200(res)
-    assert "version" in res.context
-
-
-def test_libraries_by_version_detail_no_library_found(tp, library_version):
-    """GET /versions/{version_identifier}/libraries/{slug}/"""
-    res = tp.get(
-        "library-detail-by-version",
-        library_version.version.slug,
-        "coffee",
-    )
-    tp.response_404(res)
-
-
-def test_libraries_by_version_detail_no_version_found(tp, library_version):
-    """GET /versions/{version_identifier}/libraries/{slug}/"""
-    res = tp.get(
-        "library-detail-by-version",
-        "coffee",
-        library_version.library.slug,
-    )
-    tp.response_404(res)
-
-
-def test_libraries_by_version_list(tp, library_version):
-    """GET /versions/{version_slug}/libraries/"""
-    # Create a new library_version
-    excluded_library = baker.make("libraries.Library", name="Sample")
-    res = tp.get("libraries-by-version", library_version.version.slug)
-    tp.response_200(res)
-    assert "library_list" in res.context
-
-    # Confirm that correct libraries are present
-    assert len(res.context["library_list"]) == 1
-    assert library_version.library in res.context["library_list"]
-    assert excluded_library not in res.context["library_list"]
-
-
 def test_library_detail(library, tp):
     """GET /libraries/{repo}/"""
     url = tp.reverse("library-detail", library.slug)
@@ -125,3 +48,84 @@ def test_library_detail_context_get_open_issues_count(tp, library):
     assert "open_issues_count" in response.context
     # Verify that the count only includes the one open issue for this library
     assert response.context["open_issues_count"] == 1
+
+
+def test_library_list_select_category(library, category, tp):
+    """POST /libraries/ to submit a category redirects to the libraries-by-category page"""
+    res = tp.post("libraries", data={"categories": category.pk})
+    tp.response_302(res)
+
+
+def test_library_list_by_category(library_version, category, tp):
+    """GET /libraries-by-category/{category_slug}/"""
+    library = library_version.library
+    baker.make("libraries.Library", name="Sample")
+    library.categories.add(category)
+    res = tp.get("libraries-by-category", category.slug)
+    tp.response_200(res)
+    assert "library_list" in res.context
+    assert len(res.context["library_list"]) == 1
+    assert library in res.context["library_list"]
+    assert "category" in res.context
+    assert res.context["category"] == category
+
+
+def test_libraries_by_version_by_category(tp, library_version, category):
+    """GET /versions/{version_slug}/libraries-by-category/{slug}/"""
+    library = library_version.library
+    version = library_version.version
+
+    baker.make("libraries.Library", name="Sample")
+    library.categories.add(category)
+    res = tp.get("libraries-by-version-by-category", version.slug, category.slug)
+    tp.response_200(res)
+    assert "library_list" in res.context
+    assert len(res.context["library_list"]) == 1
+    assert library in res.context["library_list"]
+    assert "category" in res.context
+    assert res.context["category"] == category
+
+
+def test_libraries_by_version_list(tp, library_version):
+    """GET /versions/{version_slug}/libraries/"""
+    # Create a new library_version
+    excluded_library = baker.make("libraries.Library", name="Sample")
+    res = tp.get("libraries-by-version", library_version.version.slug)
+    tp.response_200(res)
+    assert "library_list" in res.context
+
+    # Confirm that correct libraries are present
+    assert len(res.context["library_list"]) == 1
+    assert library_version.library in res.context["library_list"]
+    assert excluded_library not in res.context["library_list"]
+
+
+def test_libraries_by_version_detail(tp, library_version):
+    """GET /versions/{version_slug}/libraries/{slug}/"""
+    res = tp.get(
+        "library-detail-by-version",
+        library_version.version.slug,
+        library_version.library.slug,
+    )
+    tp.response_200(res)
+    assert "version" in res.context
+
+
+def test_libraries_by_version_detail_no_library_found(tp, library_version):
+    """GET /versions/{version_identifier}/libraries/{slug}/"""
+    res = tp.get(
+        "library-detail-by-version",
+        library_version.version.slug,
+        "coffee",
+    )
+    tp.response_404(res)
+
+
+def test_libraries_by_version_detail_no_version_found(tp, library_version):
+    """GET /versions/{version_identifier}/libraries/{slug}/"""
+    res = tp.get(
+        "library-detail-by-version",
+        "coffee",
+        library_version.library.slug,
+    )
+    tp.response_404(res)

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -38,6 +38,31 @@ class LibraryList(CategoryMixin, FormMixin, ListView):
         return super().get(request)
 
 
+class LibraryListByVersion(CategoryMixin, FormMixin, ListView):
+    """List all of our libraries for a specific Boost version by name"""
+
+    form_class = LibraryForm
+    paginate_by = 25
+    queryset = (
+        Library.objects.prefetch_related("authors", "categories").all().order_by("name")
+    )
+    template_name = "libraries/list.html"
+
+    def get_queryset(self):
+        version_slug = self.kwargs.get("slug")
+        return super().get_queryset().filter(library_version__version__slug=version_slug)
+
+    def post(self, request):
+        """User has submitted a form and will be redirected to the right results"""
+        form = self.get_form()
+        if form.is_valid():
+            category = form.cleaned_data["categories"][0]
+            return redirect("libraries-by-category", category=category.slug)
+        else:
+            logger.info("library_list_invalid_category")
+        return super().get(request)
+
+
 class LibraryByCategory(CategoryMixin, ListView):
     """List all of our libraries in a certain category"""
 

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -50,7 +50,9 @@ class LibraryListByVersion(CategoryMixin, FormMixin, ListView):
 
     def get_queryset(self):
         version_slug = self.kwargs.get("slug")
-        return super().get_queryset().filter(library_version__version__slug=version_slug)
+        return (
+            super().get_queryset().filter(library_version__version__slug=version_slug)
+        )
 
     def post(self, request):
         """User has submitted a form and will be redirected to the right results"""

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -84,7 +84,7 @@ class LibraryDetailByVersion(CategoryMixin, DetailView):
 
         try:
             obj = self.get_queryset().get(slug=slug)
-        except queryset.model.DoesNotExist:
+        except self.model.DoesNotExist:
             raise Http404("No library found matching the query")
         return obj
 

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -1,11 +1,13 @@
 import structlog
 
+from django.http import Http404
 from django.shortcuts import redirect
 from django.views.generic import DetailView, ListView
 from django.views.generic.edit import FormMixin
 
+from versions.models import Version
 from .forms import LibraryForm
-from .models import Category, Issue, Library, PullRequest
+from .models import Category, Issue, Library, LibraryVersion, PullRequest
 
 logger = structlog.get_logger()
 
@@ -63,6 +65,50 @@ class LibraryListByVersion(CategoryMixin, FormMixin, ListView):
         else:
             logger.info("library_list_invalid_category")
         return super().get(request)
+
+
+class LibraryDetailByVersion(CategoryMixin, DetailView):
+    """Display a single Library for a specific Boost version"""
+
+    model = Library
+    template_name = "libraries/detail.html"
+
+    def get_object(self):
+        version_slug = self.kwargs.get("version_slug")
+        slug = self.kwargs.get("slug")
+
+        if not LibraryVersion.objects.filter(
+            version__slug=version_slug, library__slug=slug
+        ).exists():
+            raise Http404("No library found matching the query")
+
+        try:
+            obj = self.get_queryset().get(slug=slug)
+        except queryset.model.DoesNotExist:
+            raise Http404("No library found matching the query")
+        return obj
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        context = self.get_context_data(object=self.object)
+        context["closed_prs_count"] = self.get_closed_prs_count(self.object)
+        context["open_issues_count"] = self.get_open_issues_count(self.object)
+        context["version"] = self.get_version()
+        return self.render_to_response(context)
+
+    def get_closed_prs_count(self, obj):
+        return PullRequest.objects.filter(library=obj, is_open=True).count()
+
+    def get_open_issues_count(self, obj):
+        return Issue.objects.filter(library=obj, is_open=True).count()
+
+    def get_version(self):
+        version_slug = self.kwargs.get("version_slug")
+        try:
+            return Version.objects.get(slug=version_slug)
+        except Version.DoesNotExist:
+            logger.info("libraries_by_version_detail_view_version_not_found")
+            raise Http404("No library for this version found matching the query")
 
 
 class LibraryByCategory(CategoryMixin, ListView):

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -159,7 +159,7 @@ class LibraryDetailByVersion(CategoryMixin, DetailView):
 
 
 class LibraryListByVersionByCategory(CategoryMixin, ListView):
-    """List all of our libraries in a certain category for a certain Boost version """
+    """List all of our libraries in a certain category for a certain Boost version"""
 
     paginate_by = 25
     template_name = "libraries/list.html"
@@ -193,8 +193,6 @@ class LibraryListByVersionByCategory(CategoryMixin, ListView):
                 categories__slug=category,
                 versions__library_version__version__slug=version_slug,
             )
-            .order_by("name").distinct()
+            .order_by("name")
+            .distinct()
         )
-
-
-


### PR DESCRIPTION
Broken off from #108 

- Adds `versions/<slug:version_slug>/<slug:slug>/` to load a library for a specific version 
- Adds `versions/<slug:version_slug>/libraries/` to load all libraries for a specific version 
- Adds `versions/<slug:version_slug>/libraries-by-category/<slug:category>/` to load all libraries for a specific version and a specific category 