### PR TITLE
:bug: Hide "Categorized" in breadcrumb if no category

### DIFF
--- a/templates/libraries/list.html
+++ b/templates/libraries/list.html
@@ -9,15 +9,15 @@
       <a class="text-orange" href="{% url 'libraries-by-version' version_slug %}">Libraries ({{ version_name }})</a>
     {% else %}
       <a class="text-orange" href="{% url 'libraries' %}">Libraries</a>
-    {% endif %} > Categorized
-      {% if category %} > 
-        <a class="text-orange" href="
-          {% if version_slug %}
-            {% url 'libraries-by-version-by-category' version_slug=version_slug category=category.slug%}
-          {% else %}
-            {% url 'libraries-by-category' category=category.slug %}
-          {% endif %}">{{ category.name }}</a>
-      {% endif %}
+    {% endif %} 
+    {% if category %} > Categorized > 
+      <a class="text-orange" href="
+        {% if version_slug %}
+          {% url 'libraries-by-version-by-category' version_slug=version_slug category=category.slug%}
+        {% else %}
+          {% url 'libraries-by-category' category=category.slug %}
+        {% endif %}">{{ category.name }}</a>
+    {% endif %}
   </div>
   <!-- end breadcrumb -->
   <div class="md:flex py-0 md:py-6 mb-3 px-3 md:px-0" x-data="{'showSearch': false}" x-on:keydown.escape="showSearch=false">


### PR DESCRIPTION
Closes #100 cc @gregnewman -- I just had some changes in that template so I added this fix really fast. Let me know if it wasn't what you had in mind. 

<img width="1378" alt="Screen Shot 2023-02-15 at 9 58 31 AM" src="https://user-images.githubusercontent.com/2286304/219114756-0f1c3392-bbb1-48bf-ab65-370262e4dfef.png">
<img width="1387" alt="Screen Shot 2023-02-15 at 9 58 40 AM" src="https://user-images.githubusercontent.com/2286304/219114763-8979ecc5-0660-492a-8668-483b9d91777f.png">
