### PR TITLE
:wrench: Only show 'current version' if it's actually the current version

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1647,6 +1647,10 @@ input[type=file] {
   background-color: rgb(23 42 52 / 0.6);
 }
 
+.bg-green\/50 {
+  background-color: rgb(90 213 153 / 0.5);
+}
+
 .bg-transparent {
   background-color: transparent;
 }
@@ -1654,6 +1658,19 @@ input[type=file] {
 .bg-slate {
   --tw-bg-opacity: 1;
   background-color: rgb(49 74 87 / var(--tw-bg-opacity));
+}
+
+.bg-orange\/10 {
+  background-color: rgb(255 159 0 / 0.1);
+}
+
+.bg-orange\/60 {
+  background-color: rgb(255 159 0 / 0.6);
+}
+
+.bg-orange {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 159 0 / var(--tw-bg-opacity));
 }
 
 .bg-opacity-70 {
@@ -2043,6 +2060,10 @@ input[type=file] {
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
+.text-white\/60 {
+  color: rgb(255 255 255 / 0.6);
+}
+
 .text-gray-100 {
   --tw-text-opacity: 1;
   color: rgb(243 244 246 / var(--tw-text-opacity));
@@ -2061,10 +2082,6 @@ input[type=file] {
 .text-silver {
   --tw-text-opacity: 1;
   color: rgb(181 201 211 / var(--tw-text-opacity));
-}
-
-.text-white\/60 {
-  color: rgb(255 255 255 / 0.6);
 }
 
 .text-gray-500 {

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -5,7 +5,7 @@
 {% block content %}
 
   <div>
-    <a class="text-orange" href="{% url "version-list" %}">Versions</a> > 1.78
+    <a class="text-orange" href="{% url "version-list" %}">Versions</a> > {{ version.name }}
   </div>
 
   <div class="flex mt-4">
@@ -21,7 +21,7 @@
     </div>
     <div class="md:w-3/4 px-3 md:px-0 mx-3 md:mx-0">
       <div class="mb-6">
-        <span class="inline uppercase text-green bg-green/10 rounded text-lg w-auto px-3 py-1">Current Version</span>
+        <span class="inline uppercase text-green bg-green/10 rounded text-lg w-auto px-3 py-1">{% if current_version %}Current Version{% else %}Past Version{% endif %}</span>
       </div>
 
       <div class="border-b border-slate py-6">

--- a/templates/versions/detail.html
+++ b/templates/versions/detail.html
@@ -21,7 +21,7 @@
     </div>
     <div class="md:w-3/4 px-3 md:px-0 mx-3 md:mx-0">
       <div class="mb-6">
-        <span class="inline uppercase text-green bg-green/10 rounded text-lg w-auto px-3 py-1">{% if current_version %}Current Version{% else %}Past Version{% endif %}</span>
+        <span class="inline uppercase {% if current_version %}text-green bg-green/10{% else %}text-orange bg-charcoal{% endif %} rounded text-lg w-auto px-3 py-1">{% if current_version %}Current Version{% else %}Past Version{% endif %}</span>
       </div>
 
       <div class="border-b border-slate py-6">

--- a/templates/versions/list.html
+++ b/templates/versions/list.html
@@ -36,13 +36,13 @@
   <!-- Past Versions -->
   <div class="rounded bg-charcoal p-3 md:p-11 mx-3 space-y-8">
     <div class="mb-6">
-      <span class="inline uppercase text-green bg-green/10 rounded text-lg w-auto px-3 py-1">Past Versions</span>
+      <span class="inline uppercase text-orange bg-black rounded text-lg w-auto px-3 py-1">Past Versions</span>
     </div>
 
     {% for v in version_list %}
       {% include "versions/_past_version_list_item.html" %}
     {% endfor %}
-    
+
   </div>
   <!-- End Past Versions -->
 

--- a/versions/views.py
+++ b/versions/views.py
@@ -25,3 +25,10 @@ class VersionDetail(DetailView):
     model = Version
     queryset = Version.objects.active()
     template_name = "versions/detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        current_version = Version.objects.most_recent()
+        obj = self.get_object()
+        context["current_version"] = bool(current_version == obj)
+        return context


### PR DESCRIPTION
@gregnewman Wanted to run this by you -- realized the version details page was showing "Current Version" undconditionally. I made it toggle between "current version" and "past version" to mimic how we do the list page: 

![Screen Shot 2023-02-17 at 1 12 23 PM](https://user-images.githubusercontent.com/2286304/219794288-5a035344-4363-4fb9-bfed-db2a45b519a4.png)
![Screen Shot 2023-02-17 at 1 10 15 PM](https://user-images.githubusercontent.com/2286304/219794293-b2a03100-7fa4-41c0-a5fa-fab98c203ab2.png)
![Screen Shot 2023-02-17 at 1 10 20 PM](https://user-images.githubusercontent.com/2286304/219794297-646a4605-ca1e-4974-911e-bc3be02f9590.png)


Do we want to think about using orange (or something else) instead of green for past versions, to make it more obvious if they are on an older version? 