### PR TITLE
#121 Allow user to import their GH profile photo 

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -12,6 +12,7 @@ from users.views import (
     UserViewSet,
     CurrentUserView,
     ProfileViewSet,
+    ProfilePhotoGitHubUpdateView,
     ProfilePhotoUploadView,
 )
 from ak.views import (
@@ -47,6 +48,11 @@ urlpatterns = (
         path("", HomepageView.as_view(), name="home"),
         path("admin/", admin.site.urls),
         path("accounts/", include("allauth.urls")),
+        path(
+            "users/me/update-github-photo/",
+            ProfilePhotoGitHubUpdateView.as_view(),
+            name="profile-photo-github",
+        ),
         path("users/me/photo/", ProfilePhotoUploadView.as_view(), name="profile-photo"),
         path("users/me/", CurrentUserView.as_view(), name="current-user"),
         path("users/<int:pk>/", ProfileViewSet.as_view(), name="profile-user"),

--- a/libraries/github.py
+++ b/libraries/github.py
@@ -22,8 +22,9 @@ def get_api():
     return GhApi(token=token)
 
 
-def get_user_by_username(api, username):
+def get_user_by_username(username):
     """Return the response from GitHub's /users/{username}/"""
+    api = get_api()
     return api.users.get_by_username(username=username)
 
 

--- a/templates/users/photo_upload.html
+++ b/templates/users/photo_upload.html
@@ -32,6 +32,14 @@
     </div>
 
     <h3>Update Profile Photo</h3>
+
+    {% if user_has_gh_username %}
+      <form method="POST" action="{% url 'profile-photo-github' %}">
+        {% csrf_token %}
+        <button class="rounded border border-orange text-orange text-sm py-2 px-3 uppercase" type="submit">Use My GitHub Photo</button>
+      </form>
+    {% endif %}
+
     <form method="POST" enctype="multipart/form-data">
       {% csrf_token %}
       <fieldset>
@@ -41,6 +49,9 @@
           <button class="rounded border border-orange text-orange text-sm py-2 px-3 uppercase" type="submit">Update</button>
       </div>
   </form>
+
+  
+
 </div>
 </div>
 {% endblock content %}

--- a/users/models.py
+++ b/users/models.py
@@ -17,9 +17,6 @@ from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
-from libraries.github import get_api as get_github_api
-from libraries.github import get_user_by_username as get_github_user
-
 
 logger = logging.getLogger(__name__)
 

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 
 from django.apps import apps
 from django.contrib.auth import get_user_model
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from config.celery import app
 from libraries.github import get_user_by_username
 
-logger = logging.getLogger(__name__)
+logger = structlog.getLogger(__name__)
 
 User = get_user_model()
 

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -1,0 +1,33 @@
+import logging
+
+from django.apps import apps
+from django.contrib.auth import get_user_model
+
+from config.celery import app
+from libraries.github import get_user_by_username
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+class UserMissingGithubUsername(Exception):
+    pass
+
+
+@app.task
+def update_user_github_photo(user_pk):
+    try:
+        user = User.objects.get(pk=user_pk)
+    except User.DoesNotExist:
+        logger.exception("users_tasks_update_gh_photo_no_user_found", user_pk=user_pk)
+        raise
+
+    if not user.github_username:
+        logger.info("users_tasks_update_gh_photo_no_github_username", user_pk=user_pk)
+        raise UserMissingGithubUsername
+
+    response = get_user_by_username(user.github_username)
+    avatar_url = response["avatar_url"]
+    user.save_image_from_github(avatar_url)
+    logger.info("users_tasks_update_gh_photo_finished", user_pk=user_pk)

--- a/users/tests/test_tasks.py
+++ b/users/tests/test_tasks.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ..tasks import UserMissingGithubUsername, update_user_github_photo
+
+
+def test_update_user_github_photo_user_not_found(db):
+    with pytest.raises(Exception):
+        update_user_github_photo(9999)
+
+
+def test_update_user_github_photo_no_gh_username(user):
+    user.github_username = ""
+    user.save()
+    with pytest.raises(UserMissingGithubUsername):
+        update_user_github_photo(user.pk)

--- a/users/tests/test_urls.py
+++ b/users/tests/test_urls.py
@@ -72,3 +72,14 @@ def test_profile_photo_update_success(tp, user, client):
     assert f"/users/{user.pk}" in res.url
     user.refresh_from_db()
     assert user.image != old_image
+
+
+def test_profile_photo_github_auth(tp, db):
+    """
+    POST /users/me/update-github-photo/
+
+    Canary test that the github photo update page is protected.
+    """
+    res = tp.post("profile-photo-github")
+    tp.response_302(res)
+    assert "/accounts/login" in res.url

--- a/users/views.py
+++ b/users/views.py
@@ -107,5 +107,5 @@ class ProfilePhotoGitHubUpdateView(UpdateView):
 
     def post(self, request, *args, **kwargs):
         user = self.get_object()
-        tasks.update_user_github_photo(user.pk)
+        tasks.update_user_github_photo.delay(user.pk)
         return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
- Adds URL and view to provide a way for a user to ask that we import their GH profile 
- Adds a celery task to retrieve their user info from the GH API 
- Celery task gets the `avatar_url` from the GH response and calls the User model method that saves an image from a URL 
- Adds a button on the "Update profile photo" page that the user can click to update their profile photo 

<img width="585" alt="Screen Shot 2023-03-02 at 9 57 19 AM" src="https://user-images.githubusercontent.com/2286304/222513534-d15fb14f-1b06-44ac-833f-22419144551a.png">
